### PR TITLE
feat: move vocabulary media to S3

### DIFF
--- a/src/main/java/controller/AddVocabularyServlet.java
+++ b/src/main/java/controller/AddVocabularyServlet.java
@@ -3,7 +3,7 @@ package controller;
 import dao.VocabularyDAO;
 import model.Vocabulary;
 import java.io.IOException;
-import java.io.InputStream;
+import util.S3ClientUtil;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.MultipartConfig;
 import jakarta.servlet.annotation.WebServlet;
@@ -14,8 +14,8 @@ import jakarta.servlet.http.HttpSession;
 import jakarta.servlet.http.Part;
 
 /**
- * Servlet xử lý việc thêm từ vựng mới, bao gồm cả việc upload file ảnh và audio
- * trực tiếp vào cơ sở dữ liệu dưới dạng BLOB.
+ * Servlet xử lý việc thêm từ vựng mới, bao gồm upload file ảnh và audio lên S3
+ * và lưu URL tương ứng vào cơ sở dữ liệu.
  */
 @WebServlet(name = "AddVocabularyServlet", urlPatterns = {"/admin/add-vocabulary-action"})
 @MultipartConfig // Bắt buộc phải có để xử lý form có file upload
@@ -47,19 +47,26 @@ public class AddVocabularyServlet extends HttpServlet {
             return;
         }
         
-        // Đọc dữ liệu của file được upload thành mảng byte[]
-        byte[] imageData = getBytesFromPart(request.getPart("imageFile"));
-        byte[] audioData = getBytesFromPart(request.getPart("audioFile"));
+        Part imagePart = request.getPart("imageFile");
+        Part audioPart = request.getPart("audioFile");
+
+        String imageUrl = null;
+        if (imagePart != null && imagePart.getSize() > 0) {
+            imageUrl = S3ClientUtil.upload(imagePart.getInputStream(), imagePart.getSubmittedFileName(), imagePart.getSize());
+        }
+
+        String audioUrl = null;
+        if (audioPart != null && audioPart.getSize() > 0) {
+            audioUrl = S3ClientUtil.upload(audioPart.getInputStream(), audioPart.getSubmittedFileName(), audioPart.getSize());
+        }
 
         // Tạo đối tượng Vocabulary mới
         Vocabulary newVocab = new Vocabulary();
         newVocab.setWord(word);
         newVocab.setMeaning(meaning);
         newVocab.setExample(example);
-        
-        // Gán dữ liệu nhị phân vào đối tượng
-        newVocab.setImageData(imageData);
-        newVocab.setAudioData(audioData);
+        newVocab.setImageUrl(imageUrl);
+        newVocab.setAudioUrl(audioUrl);
 
         // Xử lý lessonId (có thể null)
         if (lessonIdStr != null && !lessonIdStr.trim().isEmpty()) {
@@ -84,19 +91,5 @@ public class AddVocabularyServlet extends HttpServlet {
         response.sendRedirect(request.getContextPath() + "/admin/manage-vocabulary");
     }
     
-    /**
-     * Hàm trợ giúp để đọc dữ liệu từ một Part (file upload) và chuyển thành mảng byte.
-     * @param part Đối tượng Part chứa dữ liệu file.
-     * @return Mảng byte của file, hoặc null nếu không có file hoặc file rỗng.
-     * @throws IOException
-     */
-    private byte[] getBytesFromPart(Part part) throws IOException {
-        if (part == null || part.getSize() == 0) {
-            return null;
-        }
-        try (InputStream inputStream = part.getInputStream()) {
-            // inputStream.readAllBytes() là cách hiện đại để đọc toàn bộ stream
-            return inputStream.readAllBytes();
-        }
-    }
+    // Không cần phương thức trợ giúp đọc toàn bộ file vào bộ nhớ
 }

--- a/src/main/java/controller/MediaServlet.java
+++ b/src/main/java/controller/MediaServlet.java
@@ -9,11 +9,10 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.io.OutputStream;
 
 /**
- * Servlet này xử lý việc trả về dữ liệu media (ảnh, audio) cho các flashcard.
- * Nó lắng nghe tại URL /media và trả về dữ liệu byte dựa trên vocabId và type.
+ * Servlet này xử lý việc lấy URL media (ảnh, audio) cho các flashcard.
+ * Nó lắng nghe tại URL /media và chuyển hướng tới URL đã lưu trong cơ sở dữ liệu.
  */
 @WebServlet(name = "MediaServlet", urlPatterns = {"/media"})
 public class MediaServlet extends HttpServlet {
@@ -46,30 +45,17 @@ public class MediaServlet extends HttpServlet {
                 return;
             }
 
-            byte[] mediaData = null;
-            String contentType = null;
-
+            String mediaUrl = null;
             if ("image".equalsIgnoreCase(type)) {
-                mediaData = vocab.getImageData(); // Cần có getter getImageData() trong model
-                // Giả sử bạn lưu ảnh PNG hoặc JPEG. Thay đổi cho phù hợp.
-                contentType = getServletContext().getMimeType("image.jpg"); // "image/jpeg"
+                mediaUrl = vocab.getImageUrl();
             } else if ("audio".equalsIgnoreCase(type)) {
-                mediaData = vocab.getAudioData(); // Cần có getter getAudioData() trong model
-                // Giả sử bạn lưu audio MP3. Thay đổi cho phù hợp.
-                contentType = getServletContext().getMimeType("audio.mp3"); // "audio/mpeg"
+                mediaUrl = vocab.getAudioUrl();
             }
 
-            if (mediaData != null && mediaData.length > 0) {
-                response.setContentType(contentType);
-                response.setContentLength(mediaData.length);
-                
-                // Ghi dữ liệu vào response
-                try (OutputStream out = response.getOutputStream()) {
-                    out.write(mediaData);
-                }
+            if (mediaUrl != null && !mediaUrl.trim().isEmpty()) {
+                response.sendRedirect(mediaUrl);
             } else {
-                // Không có dữ liệu media tương ứng
-                response.sendError(HttpServletResponse.SC_NOT_FOUND, "Media data not found for this vocabulary.");
+                response.sendError(HttpServletResponse.SC_NOT_FOUND, "Media URL not found for this vocabulary.");
             }
 
         } catch (NumberFormatException e) {

--- a/src/main/java/model/Vocabulary.java
+++ b/src/main/java/model/Vocabulary.java
@@ -8,8 +8,8 @@ public class Vocabulary implements Serializable {
     private String meaning;
     private String example;
 
-    private transient byte[] imageData;
-    private transient byte[] audioData;
+    private String imageUrl;
+    private String audioUrl;
 
     private Integer lessonId;
     private java.sql.Timestamp createdAt;
@@ -26,8 +26,8 @@ public class Vocabulary implements Serializable {
     public String getWord() { return word; }
     public String getMeaning() { return meaning; }
     public String getExample() { return example; }
-    public byte[] getImageData() { return imageData; }
-    public byte[] getAudioData() { return audioData; }
+    public String getImageUrl() { return imageUrl; }
+    public String getAudioUrl() { return audioUrl; }
     public Integer getLessonId() { return lessonId; }
     public java.sql.Timestamp getCreatedAt() { return createdAt; }
 
@@ -40,8 +40,8 @@ public class Vocabulary implements Serializable {
     public void setWord(String word) { this.word = word; }
     public void setMeaning(String meaning) { this.meaning = meaning; }
     public void setExample(String example) { this.example = example; }
-    public void setImageData(byte[] imageData) { this.imageData = imageData; }
-    public void setAudioData(byte[] audioData) { this.audioData = audioData; }
+    public void setImageUrl(String imageUrl) { this.imageUrl = imageUrl; }
+    public void setAudioUrl(String audioUrl) { this.audioUrl = audioUrl; }
     public void setLessonId(Integer lessonId) { this.lessonId = lessonId; }
     public void setCreatedAt(java.sql.Timestamp createdAt) { this.createdAt = createdAt; }
 

--- a/src/main/java/util/S3ClientUtil.java
+++ b/src/main/java/util/S3ClientUtil.java
@@ -1,0 +1,34 @@
+package util;
+
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.InputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.util.UUID;
+
+public class S3ClientUtil {
+    private static final Region REGION = Region.AP_SOUTHEAST_1;
+    private static final String BUCKET = System.getenv().getOrDefault("S3_BUCKET", "your-bucket-name");
+    private static final S3Client CLIENT = S3Client.builder()
+            .region(REGION)
+            .credentialsProvider(DefaultCredentialsProvider.create())
+            .build();
+
+    private S3ClientUtil() {}
+
+    public static String upload(InputStream inputStream, String fileName, long contentLength) throws IOException {
+        String key = UUID.randomUUID() + "_" + fileName;
+        PutObjectRequest putReq = PutObjectRequest.builder()
+                .bucket(BUCKET)
+                .key(key)
+                .build();
+        CLIENT.putObject(putReq, RequestBody.fromInputStream(inputStream, contentLength));
+        URL url = CLIENT.utilities().getUrl(b -> b.bucket(BUCKET).key(key));
+        return url.toString();
+    }
+}

--- a/src/main/webapp/admin/editVocabulary.jsp
+++ b/src/main/webapp/admin/editVocabulary.jsp
@@ -55,10 +55,10 @@
                                     <div class="form-group">
                                         <label><i class="fas fa-image"></i> Ảnh minh họa hiện tại</label>
                                         <div>
-                                            <c:if test="${not empty vocabToEdit.imageData and vocabToEdit.imageData.length > 0}">
-                                                <img src="${pageContext.request.contextPath}/media?id=${vocabToEdit.vocabId}&type=image" alt="Ảnh minh họa" style="max-width: 200px; border-radius: 8px;">
+                                            <c:if test="${not empty vocabToEdit.imageUrl}">
+                                                <img src="${vocabToEdit.imageUrl}" alt="Ảnh minh họa" style="max-width: 200px; border-radius: 8px;">
                                             </c:if>
-                                            <c:if test="${empty vocabToEdit.imageData or vocabToEdit.imageData.length == 0}">
+                                            <c:if test="${empty vocabToEdit.imageUrl}">
                                                 <p class="text-muted">Chưa có ảnh.</p>
                                             </c:if>
                                         </div>
@@ -72,10 +72,10 @@
                                     <div class="form-group">
                                         <label><i class="fas fa-volume-up"></i> File phát âm hiện tại</label>
                                         <div>
-                                            <c:if test="${not empty vocabToEdit.audioData and vocabToEdit.audioData.length > 0}">
-                                                <audio controls src="${pageContext.request.contextPath}/media?id=${vocabToEdit.vocabId}&type=audio"></audio>
+                                            <c:if test="${not empty vocabToEdit.audioUrl}">
+                                                <audio controls src="${vocabToEdit.audioUrl}"></audio>
                                             </c:if>
-                                            <c:if test="${empty vocabToEdit.audioData or vocabToEdit.audioData.length == 0}">
+                                            <c:if test="${empty vocabToEdit.audioUrl}">
                                                 <p class="text-muted">Chưa có audio.</p>
                                             </c:if>
                                         </div>

--- a/src/main/webapp/flashcards.jsp
+++ b/src/main/webapp/flashcards.jsp
@@ -156,10 +156,9 @@
 
                     // Thêm hình ảnh nếu có
                     if (vocab.hasImage) {
-                        const imageUrl = contextPath + '/media?id=' + vocab.vocabId + '&type=image';
                         const imgEl = document.createElement('img');
                         imgEl.className = 'flashcard-img';
-                        imgEl.src = imageUrl;
+                        imgEl.src = vocab.imageUrl;
                         imgEl.alt = 'Image for ' + word;
                         cardBack.appendChild(imgEl);
                     }
@@ -173,12 +172,10 @@
 
                     // Thêm audio nếu có
                     if (vocab.hasAudio) {
-                        // Đảm bảo truy cập chính xác "vocab.vocabId"
-                        const audioUrl = contextPath + '/media?id=' + vocab.vocabId + '&type=audio';
                         const audioEl = document.createElement('audio');
                         audioEl.className = 'audio-player';
                         audioEl.controls = true;
-                        audioEl.src = audioUrl;
+                        audioEl.src = vocab.audioUrl;
                         cardBack.appendChild(audioEl);
                     }
 

--- a/src/main/webapp/lessonDetail.jsp
+++ b/src/main/webapp/lessonDetail.jsp
@@ -604,8 +604,7 @@
 
                                             <c:if test="${vocab.hasAudio}">
                                                 <div class="ml-3">
-                                                    <%-- Trỏ src đến MediaServlet để lấy dữ liệu BLOB --%>
-                                                    <audio controls class="audio-player" src="${pageContext.request.contextPath}/media?id=${vocab.vocabId}&type=audio"></audio>
+                                                    <audio controls class="audio-player" src="${vocab.audioUrl}"></audio>
                                                 </div>
                                             </c:if>
                                         </div>
@@ -617,9 +616,9 @@
                                         </c:if>
 
                                         <c:if test="${vocab.hasImage}">
-                                            <img src="${pageContext.request.contextPath}/media?id=${vocab.vocabId}&type=image" 
-                                                 alt="<c:out value='${vocab.word}'/>" 
-                                                 class="vocab-image img-thumbnail mt-2" 
+                                            <img src="${vocab.imageUrl}"
+                                                 alt="<c:out value='${vocab.word}'/>"
+                                                 class="vocab-image img-thumbnail mt-2"
                                                  style="max-height: 120px;">
                                         </c:if>
                                     </div>

--- a/src/main/webapp/vocabulary.jsp
+++ b/src/main/webapp/vocabulary.jsp
@@ -329,9 +329,9 @@
                                         </td>
                                         <td>
                                             <c:if test="${vocab.hasImage}">
-                                                <img src="${pageContext.request.contextPath}/media?id=${vocab.vocabId}&type=image" 
-                                                 alt="<c:out value='${vocab.word}'/>" 
-                                                 class="vocab-image img-thumbnail mt-2" 
+                                                <img src="${vocab.imageUrl}"
+                                                 alt="<c:out value='${vocab.word}'/>"
+                                                 class="vocab-image img-thumbnail mt-2"
                                                  style="max-height: 120px;">
                                             </c:if>
                                             <c:if test="${!vocab.hasImage}">
@@ -343,8 +343,8 @@
                                         <td><c:out value="${vocab.example}"/></td>
                                         <td>
                                             <c:if test="${vocab.hasAudio}">
-                                                <audio controls class="audio-player" 
-                                                       src="${pageContext.request.contextPath}/media?id=${vocab.vocabId}&type=audio">
+                                                <audio controls class="audio-player"
+                                                       src="${vocab.audioUrl}">
                                                 </audio>
                                             </c:if>
                                             <c:if test="${!vocab.hasAudio}">


### PR DESCRIPTION
## Summary
- store vocabulary image and audio paths as URLs instead of BLOBs
- stream uploaded files to S3 and persist returned URLs
- serve media via S3 links and update views accordingly

## Testing
- `mvn -q -e -ntp test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cb6f3bd1883328d04627c5a54f37c